### PR TITLE
Seperate request and access token

### DIFF
--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -232,11 +232,12 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
          * The storage won't send an TokenNotFoundException by itself,
          * even if only a request token is saved in the storage.
          */
-        if (empty($token->getAccessToken())) {
+        $accessTokenSecret = $token->getAccessTokenSecret();
+        if (empty($accessTokenSecret)) {
             throw new TokenNotFoundException('No access token found.');
         }
         
-        $this->signature->setTokenSecret($token->getAccessTokenSecret());
+        $this->signature->setTokenSecret($accessTokenSecret);
         $authParameters = $this->getBasicAuthorizationHeaderInfo();
         if (isset($authParameters['oauth_callback'])) {
             unset($authParameters['oauth_callback']);

--- a/src/OAuth/OAuth1/Service/BitBucket.php
+++ b/src/OAuth/OAuth1/Service/BitBucket.php
@@ -3,8 +3,6 @@
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
-use OAuth\OAuth1\Token\StdOAuth1Token;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -50,47 +48,5 @@ class BitBucket extends AbstractService
     {
         return new Uri('https://bitbucket.org/!api/1.0/oauth/access_token');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
+    
 }

--- a/src/OAuth/OAuth1/Service/Etsy.php
+++ b/src/OAuth/OAuth1/Service/Etsy.php
@@ -3,8 +3,6 @@
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
-use OAuth\OAuth1\Token\StdOAuth1Token;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -60,50 +58,7 @@ class Etsy extends AbstractService
     {
         return new Uri($this->baseApiUri . 'oauth/access_token');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
-
+    
     /**
      * Set the scopes for permissions
      * @see https://www.etsy.com/developers/documentation/getting_started/oauth#section_permission_scopes

--- a/src/OAuth/OAuth1/Service/FitBit.php
+++ b/src/OAuth/OAuth1/Service/FitBit.php
@@ -3,8 +3,6 @@
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
-use OAuth\OAuth1\Token\StdOAuth1Token;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -50,47 +48,5 @@ class FitBit extends AbstractService
     {
         return new Uri('https://api.fitbit.com/oauth/access_token');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
+    
 }

--- a/src/OAuth/OAuth1/Service/FiveHundredPx.php
+++ b/src/OAuth/OAuth1/Service/FiveHundredPx.php
@@ -10,8 +10,6 @@
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
-use OAuth\OAuth1\Token\StdOAuth1Token;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -70,51 +68,5 @@ class FiveHundredPx extends AbstractService
     {
         return new Uri('https://api.500px.com/v1/oauth/access_token');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed'])
-            || $data['oauth_callback_confirmed'] !== 'true'
-        ) {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException(
-                'Error in retrieving token: "' . $data['error'] . '"'
-            );
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
+    
 }

--- a/src/OAuth/OAuth1/Service/Flickr.php
+++ b/src/OAuth/OAuth1/Service/Flickr.php
@@ -3,8 +3,6 @@
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
-use OAuth\OAuth1\Token\StdOAuth1Token;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -41,38 +39,6 @@ class Flickr extends AbstractService
     public function getAccessTokenEndpoint()
     {
         return new Uri('https://www.flickr.com/services/oauth/access_token');
-    }
-
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-        if ($data === null || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
     }
 
     public function request($path, $method = 'GET', $body = null, array $extraHeaders = array())

--- a/src/OAuth/OAuth1/Service/QuickBooks.php
+++ b/src/OAuth/OAuth1/Service/QuickBooks.php
@@ -2,8 +2,6 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\OAuth1\Token\StdOAuth1Token;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
@@ -58,51 +56,6 @@ class QuickBooks extends AbstractService
     public function getAccessTokenEndpoint()
     {
         return new Uri('https://oauth.intuit.com/oauth/v1/get_access_token');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed'])
-            || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            $message = 'Error in retrieving token: "' . $data['error'] . '"';
-            throw new TokenResponseException($message);
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
     }
 
     /**

--- a/src/OAuth/OAuth1/Service/Redmine.php
+++ b/src/OAuth/OAuth1/Service/Redmine.php
@@ -3,8 +3,6 @@
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
-use OAuth\OAuth1\Token\StdOAuth1Token;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -50,47 +48,5 @@ class Redmine extends AbstractService
     {
         return new Uri($this->baseApiUri->getAbsoluteUri() . '/access_token');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
+    
 }

--- a/src/OAuth/OAuth1/Service/ScoopIt.php
+++ b/src/OAuth/OAuth1/Service/ScoopIt.php
@@ -3,8 +3,6 @@
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
-use OAuth\OAuth1\Token\StdOAuth1Token;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -50,47 +48,5 @@ class ScoopIt extends AbstractService
     {
         return new Uri('https://www.scoop.it/oauth/access');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
+    
 }

--- a/src/OAuth/OAuth1/Service/Tumblr.php
+++ b/src/OAuth/OAuth1/Service/Tumblr.php
@@ -3,8 +3,6 @@
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
-use OAuth\OAuth1\Token\StdOAuth1Token;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -50,47 +48,5 @@ class Tumblr extends AbstractService
     {
         return new Uri('https://www.tumblr.com/oauth/access_token');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
+    
 }

--- a/src/OAuth/OAuth1/Service/Twitter.php
+++ b/src/OAuth/OAuth1/Service/Twitter.php
@@ -3,8 +3,6 @@
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
-use OAuth\OAuth1\Token\StdOAuth1Token;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -76,48 +74,4 @@ class Twitter extends AbstractService
         return new Uri('https://api.twitter.com/oauth/access_token');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response: ' . $responseBody);
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        } elseif (!isset($data["oauth_token"]) || !isset($data["oauth_token_secret"])) {
-            throw new TokenResponseException('Invalid response. OAuth Token data not set: ' . $responseBody);
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
 }

--- a/src/OAuth/OAuth1/Service/Xing.php
+++ b/src/OAuth/OAuth1/Service/Xing.php
@@ -3,7 +3,6 @@
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
-use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Consumer\CredentialsInterface;
@@ -50,48 +49,22 @@ class Xing extends AbstractService
     {
         return new Uri('https://api.xing.com/v1/request_token');
     }
-
+    
     /**
      * {@inheritdoc}
      */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
+    protected function validateTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
         $errors = json_decode($responseBody);
-
+        
         if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
         } elseif ($errors) {
             throw new TokenResponseException('Error in retrieving token: "' . $errors->error_name . '"');
         }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
+        
+        return $data;
     }
+    
 }

--- a/src/OAuth/OAuth1/Service/Yahoo.php
+++ b/src/OAuth/OAuth1/Service/Yahoo.php
@@ -4,7 +4,6 @@ namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -84,36 +83,12 @@ class Yahoo extends AbstractService
     /**
      * {@inheritdoc}
      */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function parseAccessTokenResponse($responseBody)
     {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
+        $data = $this->validateTokenResponse($responseBody);
+        
         $token = new StdOAuth1Token();
 
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
         $token->setAccessToken($data['oauth_token']);
         $token->setAccessTokenSecret($data['oauth_token_secret']);
 


### PR DESCRIPTION
The storages themselves don't trigger if the access token is missing.
 This enables a TokenNotFoundException if you try to do a request with
 only a request token in OAuth1.